### PR TITLE
feat: add Branch Naming Policy Action

### DIFF
--- a/.github/workflows/naming-policy.yml
+++ b/.github/workflows/naming-policy.yml
@@ -1,0 +1,26 @@
+name: Branch Naming Policy Action
+
+on:
+  create:
+  delete:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  branch-naming-policy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run Branch Naming Policy Action
+        uses: nicklegan/github-repo-branch-naming-policy-action@v1.1.0
+        if: github.ref_type == 'branch' || github.ref_type == 'pull_request'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          regex: '^feature\/[A-Z]{2}\/HU-\d+\/[a-z-]+$'
+        # flags: i
+        # token: ${{ secrets.REPO_TOKEN }}
+        # delete: true


### PR DESCRIPTION
Se agrega una politica de naming para los pr's entrantes a la rama dev.

deberan seguir el siguiente formato:

feature/HU-XX/naming-policy

donde XX son los digitos de la historia de usuario y luego de eso un segmento con letras en minusculas y guiones.